### PR TITLE
Allow user to sort columns

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -8,7 +8,7 @@ class InvoicesController < ApplicationController
       .preload(:customer, invoice_lines: :product)
       .search_by(search_params)
       .distinct
-      .order(sort_params)
+      .order(*sort_params)
       .paginate(pagination_params)
   end
 
@@ -68,7 +68,7 @@ class InvoicesController < ApplicationController
   def sort_params
     return { created_at: :desc } unless params[:sort].present?
 
-    params[:sort].split(',').map do |sort_param|
+    valid_sorts = params[:sort].split(',').map do |sort_param|
       sort_param = sort_param.strip
       direction = sort_param.start_with?('-') ? :desc : :asc
       column = sort_param.gsub(/^[+-]/, '').strip
@@ -76,6 +76,8 @@ class InvoicesController < ApplicationController
       next unless ALLOWED_SORT_COLUMNS.include?(column)
       
       { column => direction }
-    end.compact.reduce({}, :merge)
+    end.compact
+
+    valid_sorts.empty? ? { created_at: :desc } : valid_sorts
   end
 end

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -78,6 +78,6 @@ class InvoicesController < ApplicationController
       { column => direction }
     end.compact
 
-    valid_sorts.empty? ? { created_at: :desc } : valid_sorts
+    valid_sorts.empty? ? [{ created_at: :desc }] : valid_sorts
   end
 end

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -1,4 +1,6 @@
 class InvoicesController < ApplicationController
+  ALLOWED_SORT_COLUMNS = %w[created_at updated_at customer_id date deadline total paid finalized id tax].freeze
+
   def index
     @invoices = Invoice
       .where(session_id: @session&.id)
@@ -70,7 +72,10 @@ class InvoicesController < ApplicationController
       sort_param = sort_param.strip
       direction = sort_param.start_with?('-') ? :desc : :asc
       column = sort_param.gsub(/^[+-]/, '').strip
+      
+      next unless ALLOWED_SORT_COLUMNS.include?(column)
+      
       { column => direction }
-    end.reduce({}, :merge)
+    end.compact.reduce({}, :merge)
   end
 end

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -66,7 +66,7 @@ class InvoicesController < ApplicationController
   end
 
   def sort_params
-    return { created_at: :desc } unless params[:sort].present?
+    return [{ created_at: :desc }] unless params[:sort].present?
 
     valid_sorts = params[:sort].split(',').map do |sort_param|
       sort_param = sort_param.strip

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -6,7 +6,7 @@ class InvoicesController < ApplicationController
       .preload(:customer, invoice_lines: :product)
       .search_by(search_params)
       .distinct
-      .order(created_at: :desc)
+      .order(sort_params)
       .paginate(pagination_params)
   end
 
@@ -61,5 +61,16 @@ class InvoicesController < ApplicationController
       )
     result[:session_id] = @session.id unless Rails.env.test?
     result
+  end
+
+  def sort_params
+    return { created_at: :desc } unless params[:sort].present?
+
+    params[:sort].split(',').map do |sort_param|
+      sort_param = sort_param.strip
+      direction = sort_param.start_with?('-') ? :desc : :asc
+      column = sort_param.gsub(/^[+-]/, '').strip
+      { column => direction }
+    end.reduce({}, :merge)
   end
 end

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -68,7 +68,7 @@ class InvoicesController < ApplicationController
   def sort_params
     return [{ created_at: :desc }] unless params[:sort].present?
 
-    valid_sorts = params[:sort].split(',').map do |sort_param|
+    valid_sorts = params[:sort].split(',').filter_map do |sort_param|
       sort_param = sort_param.strip
       direction = sort_param.start_with?('-') ? :desc : :asc
       column = sort_param.gsub(/^[+-]/, '').strip
@@ -76,7 +76,7 @@ class InvoicesController < ApplicationController
       next unless ALLOWED_SORT_COLUMNS.include?(column)
       
       { column => direction }
-    end.compact
+    end
 
     valid_sorts.empty? ? [{ created_at: :desc }] : valid_sorts
   end

--- a/schema.yml
+++ b/schema.yml
@@ -109,6 +109,12 @@ paths:
           schema:
             type: string
           example: '[{"field":"customer_id","operator":"eq","value":5}]'
+        - name: sort
+          description: Sort order columns, separated by commas
+          in: query
+          schema:
+            type: string
+            example: '+deadline,-total'
       responses:
         '200':
           description: the matching invoices

--- a/spec/requests/invoices_controller_spec.rb
+++ b/spec/requests/invoices_controller_spec.rb
@@ -64,6 +64,34 @@ describe InvoicesController do
       end
     end
 
+    describe 'sorting' do
+      let!(:invoices) do
+        [
+          create(:invoice, date: Date.new(2023, 1, 1)),
+          create(:invoice, date: Date.new(2023, 2, 1)),
+          create(:invoice, date: Date.new(2023, 3, 1))
+        ]
+      end
+
+      it 'sorts by date in ascending order' do
+        get '/invoices', params: { sort: 'date' }
+        assert_request_schema_confirm
+        assert_response_schema_confirm
+
+        expect(response.status).to eq 200
+        expect(response.parsed[:invoices].pluck(:id)).to eq invoices.map(&:id)
+      end
+
+      it 'sorts by date in descending order' do
+        get '/invoices', params: { sort: '-date' }
+        assert_request_schema_confirm
+        assert_response_schema_confirm
+
+        expect(response.status).to eq 200
+        expect(response.parsed[:invoices].pluck(:id)).to eq invoices.reverse.map(&:id)
+      end
+    end
+
     describe 'searching by customer' do
       it 'works' do
         get '/invoices', params: { filter: [{


### PR DESCRIPTION
One of the complaints we got from candidates is that they are not able to sort the columns because the api does not allow it.

We often see candidate doing "POC" of sorting in memory, which we know is bad.

This PR allows to sort using the api