### PR TITLE
Add sessions/create endpoint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# repos:
+#   - repo: local
+#     hooks:
+#       - id: rubocop
+#         name: Rubocop
+#         language: system
+#         entry: rubocop
+#         require_serial: true # for proper cache behavior
+#         files: (?x)(
+#           \.rb|
+#           \.rake|
+#           \.gemspec|
+#           \.jbuilder|
+#           Gemfile|
+#           Rakefile)$
+#         args:
+#           - --autocorrect
+#           - --server
+#           - --fail-level=convention
+    

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,25 @@
+AllCops:
+  NewCops: enable
+  SuggestExtensions: false
+  Exclude:
+    - 'db/schema.rb'
+    - 'vendor/**/*'
+    - 'bin/**/*'
+    - 'node_modules/**/*'
+
+require:
+  - rubocop-rails
+  - rubocop-rspec
+  - rubocop-factory_bot
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -25,17 +25,17 @@ gem 'jbuilder', '~> 2.7'
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
 
-gem "rack-timeout"
-gem "puma_worker_killer"
-gem "barnes"
+gem 'barnes'
+gem 'puma_worker_killer'
+gem 'rack-timeout'
 gem 'scout_apm'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'factory_bot_rails'
   gem 'rspec-rails'
   gem 'shoulda-matchers'
-  gem 'factory_bot_rails'
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end
 
 group :development do
@@ -45,9 +45,20 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+group :rubocop do
+  gem 'rubocop', require: false
+  gem 'rubocop-factory_bot', require: false
+  gem 'rubocop-inflector', require: false
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rails', require: false
+  gem 'rubocop-rspec', require: false
+  gem 'rubocop-rspec_rails', require: false
+end
 
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+
+gem 'activerecord-import'
 gem 'cancancan'
 gem 'committee'
 gem 'committee-rails'
@@ -57,13 +68,11 @@ gem 'rswag-ui'
 # gem 'open_api-rswag-ui'
 gem 'will_paginate'
 
-gem "net-smtp", "~> 0.3.1"
-
-
+gem 'net-smtp', '~> 0.3.1'
 
 gem 'base64'
 gem 'bigdecimal'
-gem 'mutex_m'
-gem 'observer'
 gem 'drb'
 gem 'logger'
+gem 'mutex_m'
+gem 'observer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
     activerecord (7.0.2.4)
       activemodel (= 7.0.2.4)
       activesupport (= 7.0.2.4)
+    activerecord-import (2.1.0)
+      activerecord (>= 4.2)
     activestorage (7.0.2.4)
       actionpack (= 7.0.2.4)
       activejob (= 7.0.2.4)
@@ -111,7 +113,10 @@ GEM
     i18n_data (0.10.0)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
+    json (2.12.0)
     json_schema (0.21.0)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
     listen (3.3.3)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -150,9 +155,12 @@ GEM
       racc (~> 1.4)
     observer (0.1.2)
     openapi_parser (0.14.0)
-    parser (3.1.2.0)
+    parallel (1.27.0)
+    parser (3.3.8.0)
       ast (~> 2.4.1)
+      racc
     pg (1.5.9)
+    prism (1.4.0)
     puma (4.3.7)
       nio4r (~> 2.0)
     puma_worker_killer (0.3.1)
@@ -191,10 +199,12 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0)
       zeitwerk (~> 2.5)
+    rainbow (3.1.1)
     rake (13.0.6)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    regexp_parser (2.10.0)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
     rspec-expectations (3.11.0)
@@ -215,6 +225,45 @@ GEM
     rswag-ui (2.5.1)
       actionpack (>= 3.1, < 7.1)
       railties (>= 3.1, < 7.1)
+    rubocop (1.75.6)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.44.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.44.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    rubocop-factory_bot (2.27.1)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
+    rubocop-inflector (1.0.0)
+      activesupport
+      rubocop
+      rubocop-rspec
+    rubocop-performance (1.25.0)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
+    rubocop-rails (2.32.0)
+      activesupport (>= 4.2.0)
+      lint_roller (~> 1.1)
+      rack (>= 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.44.0, < 2.0)
+    rubocop-rspec (3.6.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
+    rubocop-rspec_rails (2.31.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
+      rubocop-rspec (~> 3.5)
+    ruby-progressbar (1.13.0)
     scout_apm (5.1.1)
       parser
     shoulda-matchers (6.5.0)
@@ -230,6 +279,9 @@ GEM
     timeout (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
     unicode_utils (1.4.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -242,6 +294,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-import
   barnes
   base64
   bigdecimal
@@ -267,6 +320,13 @@ DEPENDENCIES
   rails (~> 7.0.2)
   rspec-rails
   rswag-ui
+  rubocop
+  rubocop-factory_bot
+  rubocop-inflector
+  rubocop-performance
+  rubocop-rails
+  rubocop-rspec
+  rubocop-rspec_rails
   scout_apm
   shoulda-matchers
   spring

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class CustomersController < ApplicationController
   def search
     query = params['query']

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class InvoicesController < ApplicationController
   ALLOWED_SORT_COLUMNS = %w[created_at updated_at customer_id date deadline total paid finalized id tax].freeze
 
@@ -72,9 +73,9 @@ class InvoicesController < ApplicationController
       sort_param = sort_param.strip
       direction = sort_param.start_with?('-') ? :desc : :asc
       column = sort_param.gsub(/^[+-]/, '').strip
-      
+
       next unless ALLOWED_SORT_COLUMNS.include?(column)
-      
+
       { column => direction }
     end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ProductsController < ApplicationController
   def search
     query = params['query']

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class SessionsController < ApplicationController
+  include ActionController::HttpAuthentication::Token::ControllerMethods
+
+  skip_load_resource only: [:create]
+  skip_before_action :load_session, only: [:create]
+  before_action :verify_token!, only: [:create]
+
+  def create
+    name = params.require(:name)
+    existing_session = Session.find_by(name: name)
+    session = existing_session || Sessions::CreateService.call(name)
+
+    render json: { id: session.id, token: session.token }, status: existing_session ? :ok : :created
+  end
+
+  private
+
+  def verify_token!
+    token = request.headers['Authorization']&.split&.last
+    return if token == 'Rails.application.credentials.jeancaisse_token'
+
+    raise InvalidTokenError
+  end
+end

--- a/app/services/sessions/create_service.rb
+++ b/app/services/sessions/create_service.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Sessions
+  class CreateService
+    INVOICE_COUNT = 15
+
+    def self.call(name)
+      new(name).send(:call)
+    end
+
+    private
+
+    def initialize(name)
+      @name = name
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        create_session!
+        create_invoices!
+        @session
+      end
+    end
+
+    def create_session!
+      @session = Session.create!(name: @name, token: SecureRandom.uuid)
+    end
+
+    def create_invoices!
+      invoices = (1..INVOICE_COUNT).map do
+        date = Date.current + Random.rand(-10..30).days
+
+        Invoice.new(
+          session_id: @session.id,
+          customer: customers.sample,
+          finalized: Random.rand(1..6) == 1,
+          date: date,
+          deadline: date + Random.rand(10..30).days,
+          invoice_lines_attributes: Random.rand(1..3).times.map do
+            product = products.sample
+            quantity = Random.rand(1..7)
+            {
+              product_id: product.id,
+              quantity: quantity,
+              unit: product.unit,
+              label: product.label,
+              vat_rate: product.vat_rate,
+              price: product.unit_price * quantity,
+              tax: product.unit_price * quantity * product.vat_rate.to_i / 100
+            }
+          end
+        )
+      end
+
+      Invoice.import!(invoices, recursive: true)
+    end
+
+    def customers
+      @customers ||= Customer.all
+    end
+
+    def products
+      @products ||= Product.all
+    end
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -11,6 +11,6 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym "RESTful"
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "API"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,4 +17,5 @@ Rails.application.routes.draw do
     end
   end
   resources :invoices, only: %i[index show create update destroy]
+  resources :sessions, only: %i[create]
 end

--- a/private_schema.yml
+++ b/private_schema.yml
@@ -1,0 +1,76 @@
+openapi: 3.0.3
+info:
+  title: Jean Test API
+  description: 'validate me with https://editor.swagger.io/'
+  contact:
+    email: thierry@pennylane.tech
+  version: 1.0.0
+tags:
+  - name: JeanTestAPI
+servers:
+  - url: '/'
+paths:
+  '/sessions':
+    post:
+      operationId: postSessions
+      summary: Create a new session for a candidate
+      parameters:
+        - name: Authorization
+          in: header
+          description: Bearer token for API authentication
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  example: 'Thierry Deo'
+              required:
+                - name
+      responses:
+        '201':
+          description: The created session
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Session'
+        '200':
+          description: The exiting session
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Session'
+        '401':
+          description: Unauthorized access
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        message:
+          type: string
+        error:
+          type: string
+      required:
+        - message
+    Session:
+      type: object
+      properties:
+        id:
+          type: integer
+        token:
+          type: string
+          format: uuid
+          example: '123e4567-e89b-12d3-a456-426614174000'
+      required:
+        - id
+        - token

--- a/spec/factories/session.rb
+++ b/spec/factories/session.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :session do
+    sequence(:name) { |n| "Candidate #{n}" }
+    token { SecureRandom.uuid }
+  end
+end

--- a/spec/requests/customers_controller_spec.rb
+++ b/spec/requests/customers_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe CustomersController do

--- a/spec/requests/invoices_controller_spec.rb
+++ b/spec/requests/invoices_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe InvoicesController do
@@ -7,7 +9,7 @@ describe InvoicesController do
     @committee_options ||= {
       schema_path: Rails.root.join('schema.yml').to_s,
       parse_response_by_content_type: true,
-      query_hash_key: 'rack.request.query_hash',
+      query_hash_key: 'rack.request.query_hash'
     }
   end
 
@@ -19,8 +21,8 @@ describe InvoicesController do
           customer: build(:customer, first_name: "#{i}"),
           invoice_lines: [
             build(:invoice_line, label: "#{2 * i}"),
-            build(:invoice_line, label: "#{2 * i + 1}"),
-          ],
+            build(:invoice_line, label: "#{2 * i + 1}")
+          ]
         )
       end
     end
@@ -98,7 +100,7 @@ describe InvoicesController do
         get '/invoices', params: { filter: [{
           field: 'customer.first_name',
           operator: 'search',
-          value: '2',
+          value: '2'
         }].to_json }
         assert_request_schema_confirm
         assert_response_schema_confirm
@@ -111,7 +113,7 @@ describe InvoicesController do
         get '/invoices', params: { filter: [{
           field: 'customer_id',
           operator: 'eq',
-          value: invoices[0].customer.id,
+          value: invoices[0].customer.id
         }].to_json }
         assert_request_schema_confirm
         assert_response_schema_confirm
@@ -148,7 +150,7 @@ describe InvoicesController do
         get '/invoices', params: { filter: [{
           field: 'customer_id',
           operator: 'eq',
-          value: invoice2.customer_id,
+          value: invoice2.customer_id
         }].to_json }
         assert_request_schema_confirm
         assert_response_schema_confirm
@@ -162,7 +164,7 @@ describe InvoicesController do
         get '/invoices', params: { filter: [{
           field: 'customer_id',
           operator: 'in',
-          value: invoices[0..2].map(&:customer_id),
+          value: invoices[0..2].map(&:customer_id)
         }].to_json }
         assert_request_schema_confirm
         assert_response_schema_confirm
@@ -200,7 +202,7 @@ describe InvoicesController do
             id: invoice.invoice_lines[0].id,
             _destroy: true
           }]
-        }}, as: :json
+        } }, as: :json
         assert_request_schema_confirm
         assert_response_schema_confirm
         expect(response.status).to eq 200
@@ -217,7 +219,7 @@ describe InvoicesController do
             id: invoice.invoice_lines[0].id,
             quantity: line.quantity + 1
           }]
-        }}, as: :json
+        } }, as: :json
         assert_request_schema_confirm
         assert_response_schema_confirm
         expect(response.status).to eq 200
@@ -237,9 +239,9 @@ describe InvoicesController do
             quantity: 1,
             unit: 'piece',
             vat_rate: '20',
-            price: 100,
+            price: 100
           }]
-        }}, as: :json
+        } }, as: :json
         assert_request_schema_confirm
         assert_response_schema_confirm
         expect(response.status).to eq 200
@@ -256,7 +258,7 @@ describe InvoicesController do
     it 'renders a validation error if no customer is given' do
       post '/invoices', params: { invoice: {
         date: Date.current
-      }}, as: :json
+      } }, as: :json
 
       expect(response.status).to eq 422
       expect(response.parsed[:message]).to include 'Customer must exist'
@@ -264,8 +266,8 @@ describe InvoicesController do
 
     it 'works properly with only a customer' do
       post '/invoices', params: { invoice: {
-        customer_id: customer.id,
-      }}, as: :json
+        customer_id: customer.id
+      } }, as: :json
       assert_request_schema_confirm
       assert_response_schema_confirm
 
@@ -286,9 +288,9 @@ describe InvoicesController do
           label: 'Produit',
           vat_rate: '20',
           price: 120,
-          tax: 20,
+          tax: 20
         }]
-      }}, as: :json
+      } }, as: :json
       assert_request_schema_confirm
       assert_response_schema_confirm
 

--- a/spec/requests/products_controller_spec.rb
+++ b/spec/requests/products_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe ProductsController do

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SessionsController do
+  include Committee::Rails::Test::Methods
+
+  def committee_options
+    @committee_options ||= {
+      schema_path: Rails.root.join('private_schema.yml').to_s,
+      parse_response_by_content_type: true,
+      query_hash_key: 'rack.request.query_hash'
+    }
+  end
+
+  describe '#create' do
+    let(:token) { 'test_token' }
+    let!(:customers) { create_list(:customer, 5) }
+    let!(:products) { create_list(:product, 3) }
+
+    before do
+      allow(Rails.application.credentials).to receive(:jeancaisse_token).and_return(token)
+    end
+
+    context 'with valid authentication' do
+      let(:headers) { { 'Authorization' => "Bearer #{token}" } }
+
+      it 'creates a new session when name does not exist' do
+        expect do
+          post sessions_path, params: { name: 'Thierry Deo' }, as: :json, headers: headers
+        end.to change(Session, :count).by(1).and change(Invoice, :count).by(15)
+
+        assert_request_schema_confirm
+        assert_response_schema_confirm
+        expect(response).to have_http_status(:created)
+
+        last_session = Session.last
+
+        expect(response.parsed[:id]).to eq(last_session.id)
+        expect(response.parsed[:token]).to be_present
+
+        expect(Invoice.where(session_id: last_session.id).count).to eq(15)
+      end
+
+      context 'when a session for this name already exists' do
+        let!(:existing_session) { create(:session, name: 'Thierry Deo') }
+
+        it 'returns the existing session' do
+          expect do
+            post sessions_path, params: { name: 'Thierry Deo' }, as: :json, headers: headers
+          end.not_to change(Session, :count)
+
+          assert_request_schema_confirm
+          assert_response_schema_confirm
+          expect(response).to have_http_status(:ok)
+
+          expect(response.parsed[:id]).to eq(existing_session.id)
+          expect(response.parsed[:token]).to eq(existing_session.token)
+        end
+      end
+
+      context 'when the name is not provided' do
+        it 'returns a unprocessable_entity request' do
+          post sessions_path, params: {}, as: :json, headers: headers
+
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    context 'with invalid authentication' do
+      it 'returns unauthorized when invalid token provided' do
+        post sessions_path, params: { name: 'Thierry Deo' }, as: :json,
+                            headers: { 'Authorization' => 'Bearer invalid_token' }
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.body).to eq('Invalid token')
+      end
+    end
+  end
+end

--- a/spec/services/sessions/create_service_spec.rb
+++ b/spec/services/sessions/create_service_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Sessions::CreateService do
+  let(:session_name) { 'Thierry Deo' }
+  let!(:customers) { create_list(:customer, 5) }
+  let!(:products) { create_list(:product, 3) }
+
+  describe '.call' do
+    it 'creates a new session with the given name' do
+      expect do
+        described_class.call(session_name)
+      end.to change(Session, :count).by(1)
+
+      session = Session.last
+      expect(session.name).to eq(session_name)
+      expect(session.token).to be_present
+    end
+
+    it 'creates 15 invoices for the new session' do
+      expect do
+        described_class.call(session_name)
+      end.to change(Invoice, :count).by(15).and change(InvoiceLine, :count)
+
+      session = Session.last
+      expect(Invoice.where(session_id: session.id).count).to eq(15)
+    end
+  end
+end


### PR DESCRIPTION
# Why do we need this? What are the issues solved by these changes?

We would like to be able to create a new candidate token using the API. The plan is to call this endpoint from Jeancaisse.

This is part of a broader initiative to improve our recruitment candidate experience (see [here](https://github.com/pennylane-hq/jeancaisse/pull/100465)).

TODO:
- save the token in the credentials?  